### PR TITLE
Add standalone pool watcher CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,9 @@ bs58 = "0.5"
 base64 = "0.22"
 once_cell = "1"
 solana-commitment-config = "3.0.0"
+clap = { version = "4", features = ["derive"] }
+toml = "0.8"
+
+[[bin]]
+name = "pool-watcher"
+path = "src/bin/pool-watcher.rs"

--- a/pool-watcher.toml
+++ b/pool-watcher.toml
@@ -1,0 +1,15 @@
+rpc_url = "https://api.mainnet-beta.solana.com"
+ws_url = "wss://api.mainnet-beta.solana.com"
+periodic_resync_min = 30
+
+[[programs]]
+kind = "OrcaWhirlpools"
+id = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc"
+
+[[programs]]
+kind = "RaydiumClmm"
+id = "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK"
+
+[[programs]]
+kind = "RaydiumCpmm"
+id = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8"

--- a/src/bin/pool-watcher.rs
+++ b/src/bin/pool-watcher.rs
@@ -1,0 +1,43 @@
+use std::{fs, path::PathBuf, sync::Arc};
+use clap::Parser;
+use pool_watcher::{PoolBus, PoolWatcher, PoolWatcherConfig, TokenIntrospectionProvider};
+use solana_sdk::pubkey::Pubkey;
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Args {
+    /// Path to TOML configuration file
+    #[arg(short, long, default_value = "pool-watcher.toml")]
+    config: PathBuf,
+}
+
+struct NoopTokenProvider;
+
+impl TokenIntrospectionProvider for NoopTokenProvider {
+    fn is_token2022(&self, _mint: &Pubkey) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let cfg: PoolWatcherConfig = match fs::read_to_string(&args.config) {
+        Ok(data) => toml::from_str(&data)?,
+        Err(_) => PoolWatcherConfig::default(),
+    };
+
+    let bus = Arc::new(PoolBus::new(1024));
+    let token = Arc::new(NoopTokenProvider);
+    let watcher = PoolWatcher::new(cfg, bus.clone(), token);
+    watcher.spawn();
+
+    let mut rx = bus.subscribe();
+    loop {
+        match rx.blocking_recv() {
+            Ok(ev) => println!("{:?}", ev),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+            Err(_) => break,
+        }
+    }
+    Ok(())
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -14,7 +14,7 @@ use solana_client::{
 };
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::pubkey::Pubkey;
-use std::{sync::Arc, thread};
+use std::{str::FromStr, sync::Arc, thread};
 use tokio::{
     runtime::Builder,
     time::{sleep, Duration},
@@ -33,6 +33,37 @@ pub struct PoolWatcherConfig {
     pub ws_url: String,
     pub programs: Vec<ProgramConfig>,
     pub periodic_resync_min: u64,
+}
+
+impl Default for PoolWatcherConfig {
+    fn default() -> Self {
+        Self {
+            rpc_url: "https://api.mainnet-beta.solana.com".into(),
+            ws_url: "wss://api.mainnet-beta.solana.com".into(),
+            periodic_resync_min: 30,
+            programs: vec![
+                ProgramConfig {
+                    kind: DexKind::OrcaWhirlpools,
+                    id: Pubkey::from_str("whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc")
+                        .expect("program id"),
+                },
+                ProgramConfig {
+                    kind: DexKind::RaydiumClmm,
+                    id: Pubkey::from_str(
+                        "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",
+                    )
+                    .expect("program id"),
+                },
+                ProgramConfig {
+                    kind: DexKind::RaydiumCpmm,
+                    id: Pubkey::from_str(
+                        "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
+                    )
+                    .expect("program id"),
+                },
+            ],
+        }
+    }
 }
 
 pub struct PoolWatcher {


### PR DESCRIPTION
## Summary
- support TOML configuration with `PoolWatcherConfig` defaults for mainnet Orca and Raydium programs
- update CLI to load config from `pool-watcher.toml` or fall back to built-in defaults
- provide sample `pool-watcher.toml` with mainnet endpoints and program IDs

## Testing
- `cargo test`
- `cargo run --bin pool-watcher -- --help`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfde75f48330a314c760b7fbc8ef