### PR TITLE
Migrate to async Solana pubsub client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "bs58",
  "clap",
  "dashmap 6.1.0",
+ "futures",
  "once_cell",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = "1"
 solana-commitment-config = "3.0.0"
 clap = { version = "4", features = ["derive"] }
 toml = "0.9"
+futures = "0.3"
 
 [[bin]]
 name = "pool-watcher"

--- a/token-safety-inspector/crates/token_safety/src/report.rs
+++ b/token-safety-inspector/crates/token_safety/src/report.rs
@@ -1,6 +1,27 @@
 use serde::{Serialize, Deserialize};
 use solana_sdk::pubkey::Pubkey;
 
+mod pubkey_serde {
+    use std::str::FromStr;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use solana_sdk::pubkey::Pubkey;
+
+    pub fn serialize<S>(pk: &Pubkey, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&pk.to_string())
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Pubkey, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Pubkey::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 /// Which token program owns the mint account.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -35,6 +56,7 @@ pub struct TransferFeeInfo {
 /// Result of analyzing a mint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SafetyReport {
+    #[serde(with = "pubkey_serde")]
     pub mint: Pubkey,
     pub program_owner: ProgramOwner,
     pub decimals: u8,


### PR DESCRIPTION
## Summary
- switch to `nonblocking::pubsub_client::PubsubClient`
- replace deprecated `base64::decode`
- parse base58 program ids in config and reports
- add futures dependency

## Testing
- `cargo test`
- `cargo test --manifest-path token-safety-inspector/Cargo.toml`
- `cargo run --bin pool-watcher`

------
https://chatgpt.com/codex/tasks/task_e_68b833c00c708330abf53be4b6390bfe