### PR TITLE
Use TOML config for arb-notify

### DIFF
--- a/arb-config.toml
+++ b/arb-config.toml
@@ -1,6 +1,31 @@
 rpc_url = "https://api.mainnet-beta.solana.com"
 ws_url = "wss://api.mainnet-beta.solana.com"
 periodic_resync_min = 30
+out_dir = "./outbox"
+probe_amount = 1000000
+quote_mints = []
+
+[hype]
+bucket_secs = 10
+window60s = 60
+window300s = 300
+w_swaps = 0.35
+w_unique = 0.35
+w_bsr = 0.20
+w_lp = 0.10
+
+[policy]
+require_freeze_authority_none = true
+forbid_non_transferable = true
+forbid_default_frozen = true
+forbid_permanent_delegate = true
+forbid_transfer_hook = true
+forbid_confidential = true
+max_fee_bps = 100
+max_fee_absolute = 0
+allow_mint_authority = false
+forbid_memo_required_if_route_has_no_memo = true
+forbid_mint_close_authority = false
 
 [[telegram]]
 TG_BOT_TOKEN=""

--- a/crates/hype_score/src/lib.rs
+++ b/crates/hype_score/src/lib.rs
@@ -15,22 +15,45 @@ pub struct PoolLogEvent {
     pub trader: Option<Pubkey>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HypeConfig {
+    #[serde(default = "default_bucket_secs")]
     pub bucket_secs: u64,
+    #[serde(default = "default_window60s")]
     pub window60s: u64,
+    #[serde(default = "default_window300s")]
     pub window300s: u64,
+    #[serde(default = "default_w_swaps")]
     pub w_swaps: f32,
+    #[serde(default = "default_w_unique")]
     pub w_unique: f32,
+    #[serde(default = "default_w_bsr")]
     pub w_bsr: f32,
+    #[serde(default = "default_w_lp")]
     pub w_lp: f32,
 }
 
 impl Default for HypeConfig {
     fn default() -> Self {
-        Self { bucket_secs:10, window60s:60, window300s:300, w_swaps:0.35, w_unique:0.35, w_bsr:0.20, w_lp:0.10 }
+        Self {
+            bucket_secs: default_bucket_secs(),
+            window60s: default_window60s(),
+            window300s: default_window300s(),
+            w_swaps: default_w_swaps(),
+            w_unique: default_w_unique(),
+            w_bsr: default_w_bsr(),
+            w_lp: default_w_lp(),
+        }
     }
 }
+
+fn default_bucket_secs() -> u64 { 10 }
+fn default_window60s() -> u64 { 60 }
+fn default_window300s() -> u64 { 300 }
+fn default_w_swaps() -> f32 { 0.35 }
+fn default_w_unique() -> f32 { 0.35 }
+fn default_w_bsr() -> f32 { 0.20 }
+fn default_w_lp() -> f32 { 0.10 }
 
 #[derive(Default, Clone)]
 struct Bucket {


### PR DESCRIPTION
## Summary
- load arb-notify settings from `arb-config.toml`
- add `TgConfig` struct and builder to configure Telegram publisher
- move policy and hype settings into TOML and rely on serde defaults for config fields

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c07690e21c83309189acd79d2cc1c5