### PR TITLE
Handle short mint data in token safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AI Development Notes
+
+- Run `cargo fmt --all` before committing.
+- Run `cargo test` to execute the workspace test suite.
+- When decoding SPL Token mint accounts, ensure the account data length is at least `spl_token::state::Mint::LEN` to avoid panics from `unpack_from_slice`.

--- a/crates/token_safety/crates/token_safety/src/mint_reader.rs
+++ b/crates/token_safety/crates/token_safety/src/mint_reader.rs
@@ -1,12 +1,12 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use solana_sdk::account::Account;
 use solana_sdk::pubkey::Pubkey;
-use spl_token::state as spl_v1;
 use spl_token::solana_program::program_pack::Pack;
+use spl_token::state as spl_v1;
 use std::str::FromStr;
 
 use crate::extensions::analyze_extensions;
-use crate::report::{SafetyReport, Flags, ProgramOwner};
+use crate::report::{Flags, ProgramOwner, SafetyReport};
 
 /// Analyze mint account.
 pub fn analyze_mint(account: &Account, now_epoch: u64, _probe_amount: u64) -> Result<SafetyReport> {
@@ -14,8 +14,19 @@ pub fn analyze_mint(account: &Account, now_epoch: u64, _probe_amount: u64) -> Re
     let owner = account.owner;
     let token2022_id = Pubkey::from_str("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb").unwrap();
     let token_v1_id = Pubkey::from_str("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA").unwrap();
+
+    // Helper to safely decode a mint account. Returns None if data is too short
+    // or fails to unpack.
+    fn unpack_mint(data: &[u8]) -> Option<spl_v1::Mint> {
+        if data.len() < spl_v1::Mint::LEN {
+            return None;
+        }
+        // Only decode the portion of the slice needed by the mint structure
+        spl_v1::Mint::unpack_from_slice(&data[..spl_v1::Mint::LEN]).ok()
+    }
+
     if owner == token_v1_id {
-        let mint = spl_v1::Mint::unpack_from_slice(&account.data)?;
+        let mint = unpack_mint(&account.data).ok_or_else(|| anyhow!("invalid SPL Token mint"))?;
         let flags = Flags {
             mint_authority_none: mint.mint_authority.is_none(),
             freeze_authority_none: mint.freeze_authority.is_none(),
@@ -31,7 +42,7 @@ pub fn analyze_mint(account: &Account, now_epoch: u64, _probe_amount: u64) -> Re
             other_extensions: vec![],
         })
     } else if owner == token2022_id {
-        let mint = spl_v1::Mint::unpack_from_slice(&account.data)?;
+        let mint = unpack_mint(&account.data).ok_or_else(|| anyhow!("invalid Token-2022 mint"))?;
         let (mut flags, transfer_fee, other_ext) = analyze_extensions(&account.data, now_epoch);
         flags.mint_authority_none = mint.mint_authority.is_none();
         flags.freeze_authority_none = mint.freeze_authority.is_none();
@@ -45,7 +56,7 @@ pub fn analyze_mint(account: &Account, now_epoch: u64, _probe_amount: u64) -> Re
             other_extensions: other_ext,
         })
     } else {
-        let mint = spl_v1::Mint::unpack_from_slice(&account.data).ok();
+        let mint = unpack_mint(&account.data);
         let decimals = mint.map(|m| m.decimals).unwrap_or(0);
         let supply = mint.map(|m| m.supply).unwrap_or(0);
         Ok(SafetyReport {
@@ -59,4 +70,3 @@ pub fn analyze_mint(account: &Account, now_epoch: u64, _probe_amount: u64) -> Re
         })
     }
 }
-


### PR DESCRIPTION
## Summary
- decode SPL Token mints only when account data is long enough to avoid panics
- document standard workflow and mint decoding caveat for future contributors in `AGENTS.md`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c1da6ffb9c833088a7a5115ad24e0d