### PR TITLE
Add Telegram publisher integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Test Telegram config
+tests/tg_publisher_config.toml

--- a/tests/tg_publisher.rs
+++ b/tests/tg_publisher.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use common_types::{PoolTokenBundle, TokenExtensionFlags, TokenProgramKind, TokenSafetyReport};
+use solana_sdk::pubkey::Pubkey;
+use tg_publisher::{TgConfig, TgPublisher};
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+#[ignore]
+async fn send_message_to_telegram() -> Result<()> {
+    let cfg_str = std::fs::read_to_string("tests/tg_publisher_config.toml")
+        .expect("missing test config: tests/tg_publisher_config.toml");
+    let cfg: TgConfig = toml::from_str(&cfg_str)?;
+
+    let publisher = TgPublisher::new(cfg)?;
+
+    let token_report = TokenSafetyReport {
+        mint: Pubkey::new_unique(),
+        program: TokenProgramKind::TokenV1,
+        decimals: 0,
+        supply: 0,
+        mint_authority_none: true,
+        freeze_authority_none: true,
+        flags: TokenExtensionFlags::default(),
+        decision_safe: true,
+        reasons: vec!["integration test".to_string()],
+        warnings: vec![],
+    };
+    let bundle = PoolTokenBundle {
+        pool: Pubkey::new_unique(),
+        program: Pubkey::new_unique(),
+        token_a: token_report.clone(),
+        token_b: token_report,
+        fee_bps: Some(0),
+        tick_spacing: Some(1),
+        ts_ms: 0,
+    };
+
+    publisher.send_pool_bundle(&bundle).await?;
+    sleep(Duration::from_secs(1)).await;
+
+    Ok(())
+}

--- a/tests/tg_publisher_config.example.toml
+++ b/tests/tg_publisher_config.example.toml
@@ -1,0 +1,4 @@
+# Copy to tg_publisher_config.toml and fill with real credentials
+TG_BOT_TOKEN = "replace_with_token"
+TG_CHANNEL_ID = "replace_with_channel_id"
+TG_SEND_JSON_ATTACHMENT = false


### PR DESCRIPTION
## Summary
- add ignored integration test that sends a pool bundle message using `tg_publisher`
- provide example Telegram config and ignore real credentials

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c260396fa4833082c820d3613b8ef5